### PR TITLE
Update base image versions to Debian Trixie

### DIFF
--- a/snmpd/build.yaml
+++ b/snmpd/build.yaml
@@ -1,9 +1,9 @@
 build_from:
-  aarch64: "ghcr.io/home-assistant/aarch64-base-debian:bookworm"
-  amd64: "ghcr.io/home-assistant/amd64-base-debian:bookworm"
-  armhf: "ghcr.io/home-assistant/armhf-base-debian:bookworm"
-  armv7: "ghcr.io/home-assistant/armv7-base-debian:bookworm"
-  i386: "ghcr.io/home-assistant/i386-base-debian:bookworm"
+  aarch64: "ghcr.io/home-assistant/aarch64-base-debian:trixie"
+  amd64: "ghcr.io/home-assistant/amd64-base-debian:trixie"
+  armhf: "ghcr.io/home-assistant/armhf-base-debian:trixie"
+  armv7: "ghcr.io/home-assistant/armv7-base-debian:trixie"
+  i386: "ghcr.io/home-assistant/i386-base-debian:trixie"
 labels:
   org.opencontainers.image.title: "SNMPD"
   org.opencontainers.image.description: "Monitor your HA installation via snmp"


### PR DESCRIPTION
- this updates the used base images to Debian Trixie 
- further in Debian Trixie the snmpd package is already updated to 5.9.4, which fixes #12